### PR TITLE
feat: add variable controlling assumable roles

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -116,6 +116,17 @@ data "aws_iam_policy_document" "lambda_exec_policy" {
     ]
     resources = ["*"] // Needed for discovery
   }
+
+  dynamic "statement" {
+    for_each = length(var.assumable_roles) > 0 ? [1] : []
+    content {
+      effect = "Allow"
+      actions = [
+        "sts:AssumeRole"
+      ]
+      resources = var.assumable_roles
+    }
+  }
 }
 
 resource "aws_iam_policy" "lambda_exec_policy" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -105,3 +105,9 @@ variable "eventbridge_schedule_expression" {
   type        = string
   default     = "rate(5 minutes)"
 }
+
+variable "assumable_roles" {
+  description = "List of IAM roles that can be assumed by the Lambda role."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
- adds variable for assumable roles, which reflects in the lambda iam policy, for cross account metrics delivery