### PR TITLE
Allow other Prometheus deployments in Terraform

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -27,7 +27,7 @@ resource "aws_lambda_function" "this" {
   role          = aws_iam_role.lambda.arn
   handler       = "bootstrap"
   filename =    "../yac-p.zip"
-  runtime       = "provided.al2"
+  runtime       = var.lambda_runtime
   architectures = ["arm64"]
 
   environment {

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -32,7 +32,7 @@ resource "aws_lambda_function" "this" {
       PROMETHEUS_REGION           = var.prometheus_region == "" ? data.aws_region.current.name : var.prometheus_region
       CONFIG_S3_PATH              = var.config_path == "" ? format("%s-yace-config/config.yaml", var.name_prefix) : var.config_path
       CONFIG_S3_BUCKET            = var.create_config_file_bucket ? aws_s3_bucket.this[0].bucket : var.config_bucket
-      AUTH_TYPE                   = var.create_amp_workspace ? "aws4" : var.prometheus_auth_type
+      AUTH_TYPE                   = var.create_amp_workspace ? "AWS" : var.prometheus_auth_type
       AWS_ROLE_ARN                = var.prometheus_remote_write_role_arn
     }, var.yace_options)
   }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -36,7 +36,7 @@ resource "aws_lambda_function" "this" {
       PROMETHEUS_REGION           = var.prometheus_region == "" ? data.aws_region.current.name : var.prometheus_region
       CONFIG_S3_PATH              = var.config_path == "" ? format("%s-yace-config/config.yaml", var.name_prefix) : var.config_path
       CONFIG_S3_BUCKET            = var.create_config_file_bucket ? aws_s3_bucket.this[0].bucket : var.config_bucket
-      AUTH_TYPE                   = "AWS"
+      AUTH_TYPE                   = var.create_amp_workspace ? "aws4" : var.prometheus_auth_type
       AWS_ROLE_ARN                = var.prometheus_remote_write_role_arn
     }, var.yace_options)
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -113,3 +113,8 @@ variable "prometheus_auth_type" {
   type        = string
   default     = "aws4"
 }
+variable "lambda_runtime" {
+  description = "The runtime for the Lambda function."
+  type        = string
+  default     = "provided.al2"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -108,3 +108,8 @@ variable "prometheus_remote_write_role_arn" {
   type        = string
   default     = ""
 }
+variable "prometheus_auth_type" {
+  description = "The authentication type to use for Prometheus remote write. Used when not using Amazon Managed Prometheus or other AWS authentication."
+  type        = string
+  default     = "aws4"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -109,9 +109,9 @@ variable "prometheus_remote_write_role_arn" {
   default     = ""
 }
 variable "prometheus_auth_type" {
-  description = "The authentication type to use for Prometheus remote write. Used when not using Amazon Managed Prometheus or other AWS authentication."
+  description = "The authentication type to use for Prometheus remote write. Use when not using Amazon Managed Prometheus or other AWS authentication."
   type        = string
-  default     = "aws4"
+  default     = ""
 }
 variable "lambda_runtime" {
   description = "The runtime for the Lambda function."


### PR DESCRIPTION
This pull request includes significant updates to the Terraform configuration for managing AWS Lambda functions. The changes primarily focus on improving the build process and adding flexibility to the configuration.

### Improvements to build process:

* [`terraform/lambda.tf`](diffhunk://#diff-63b9e08c8fd20e5cd26c81ae80216d00316fd0d2cf48f356416b02be4b5cfa9cL1-R35): Replaced the `random_pet` resource with a `local_file` data source to track changes in the `main.go` file and trigger the build process.
* [`terraform/lambda.tf`](diffhunk://#diff-63b9e08c8fd20e5cd26c81ae80216d00316fd0d2cf48f356416b02be4b5cfa9cL1-R35): Updated the `null_resource` build triggers to use the content of the `local_file` data source instead of the `random_pet` resource.

### Configuration flexibility:

* [`terraform/lambda.tf`](diffhunk://#diff-63b9e08c8fd20e5cd26c81ae80216d00316fd0d2cf48f356416b02be4b5cfa9cL1-R35): Added a new `lambda_runtime` variable to allow specifying the runtime for the Lambda function, replacing the hardcoded value.
* [`terraform/lambda.tf`](diffhunk://#diff-63b9e08c8fd20e5cd26c81ae80216d00316fd0d2cf48f356416b02be4b5cfa9cL1-R35): Modified the `aws_lambda_function` resource to use the new `lambda_runtime` variable and added `source_code_hash` to ensure the function is updated when the code changes.
* [`terraform/variables.tf`](diffhunk://#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4R111-R120): Introduced new variables `prometheus_auth_type` and `lambda_runtime` to provide more configuration options for authentication and runtime settings.