### PR TITLE
fix: remove the need for remote write role in assumable roles

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -109,13 +109,14 @@ data "aws_iam_policy_document" "lambda_exec_policy" {
   }
 
   dynamic "statement" {
-    for_each = length(var.assumable_roles) > 0 ? [1] : []
+    for_each = length(var.assumable_roles) > 0 || var.prometheus_remote_write_role_arn != "" ? [1] : []
     content {
       effect = "Allow"
       actions = [
         "sts:AssumeRole"
       ]
-      resources = var.assumable_roles
+      # If prometheus_remote_write_role_arn is set, add it to the list of assumable roles if it's not already there
+      resources = var.prometheus_remote_write_role_arn != "" && !contains(var.assumable_roles, var.prometheus_remote_write_role_arn) ? concat(var.assumable_roles, [var.prometheus_remote_write_role_arn]) : var.assumable_roles
     }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -98,13 +98,13 @@ variable "eventbridge_schedule_expression" {
 }
 
 variable "assumable_roles" {
-  description = "List of IAM role ARNs to add to IAM policy for Lambda to be able to assume. Used for cross-account access."
+  description = "List of IAM role ARNs to add to IAM policy for Lambda to be able to assume. Used for cross-account access. If a prometheus_remote_write_role_arn is provided, it will be added to this list automatically."
   type        = list(string)
   default     = []
 }
 
 variable "prometheus_remote_write_role_arn" {
-  description = "The ARN of the IAM role to use to remote write to Prometheus (AMP only)."
+  description = "The ARN of the IAM role to use to remote write to Prometheus (AMP only). Will be added to list of assumable roles if not already present."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
- the assumable roles in the lambda policy will now pick up the prometheus remote write role if it's not already specified in the assumable roles variable