### PR TITLE
ci: add golangci-lint workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,26 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.0
+          working-directory: ./

--- a/main.go
+++ b/main.go
@@ -97,7 +97,10 @@ func HandleRequest() {
 	registry := prometheus.NewRegistry() // Create a new prometheus registry
 
 	for _, metric := range yace.Metrics { // Register YACE internal metrics
-		registry.Register(metric)
+		err := registry.Register(metric)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	// Create a new yace client factory
@@ -271,7 +274,7 @@ func createAWSSession() (*session.Session, error) {
 func getYaceOptions(logger *slog.Logger) []yace.OptionsFunc {
 	optFuncs := []yace.OptionsFunc{}
 
-	var cloudwatchPerApiConcurrencyLimit bool = false
+	var cloudwatchPerApiConcurrencyLimit bool
 	var err error
 	perApiLimit := os.Getenv("YACE_CLOUDWATCH_CONCURRENCY_PER_API_LIMIT_ENABLED")
 	if perApiLimit != "" {


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to run `golangci-lint` on the repository. The workflow is triggered on pushes to the `main` and `master` branches, as well as on pull requests. 

Key changes include:

* Added a new workflow configuration file `.github/workflows/golangci-lint.yml` to set up and run `golangci-lint` using GitHub Actions.