### PR TITLE
ci: publish go package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,13 @@
+name: publish
+on:
+  release:
+    types:
+      - published
+jobs:
+  bump-index:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2.3.4
+      - name: Publish Go package
+        run: curl "https://proxy.golang.org/github.com/kjansson/yac-p/@v/$(git describe HEAD --tags --abbrev=0).info"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,5 +1,7 @@
 package controller
 
+// Package controller provides the Controller struct and its methods to manage the components of the application
+
 import (
 	"github.com/kjansson/yac-p/pkg/types"
 	io_prometheus_client "github.com/prometheus/client_model/go"

--- a/pkg/loaders/loaders.go
+++ b/pkg/loaders/loaders.go
@@ -1,5 +1,7 @@
 package loaders
 
+// Package loaders provides functions to load configuration files from different sources
+
 import (
 	"fmt"
 	"io"
@@ -10,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
+// GetS3Loader returns a function that loads the config from S3
 func GetS3Loader() func() ([]byte, error) {
 	return func() ([]byte, error) {
 		var content []byte
@@ -41,6 +44,7 @@ func GetS3Loader() func() ([]byte, error) {
 	}
 }
 
+// GetLocalFileLoader returns a function that loads the config from a local file
 func GetLocalFileLoader() func() (content []byte, err error) {
 	return func() (content []byte, err error) {
 		configFilePath := os.Getenv("CONFIG_FILE_PATH")

--- a/pkg/logger/log.go
+++ b/pkg/logger/log.go
@@ -1,5 +1,7 @@
 package logger
 
+// Package logger provides a simple logging interface yac-p
+
 import (
 	"log/slog"
 	"os"

--- a/pkg/prom/prometheus.go
+++ b/pkg/prom/prometheus.go
@@ -1,5 +1,7 @@
 package prom
 
+// Package prom provides a client for processing and sending metrics to a Prometheus remote write endpoint.
+
 import (
 	"bytes"
 	"fmt"

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,5 +1,7 @@
 package types
 
+// Package types defines interfaces and constants used in yac-p
+
 import (
 	yace "github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg"
 	"github.com/prometheus/client_golang/prometheus"

--- a/pkg/yace/yace.go
+++ b/pkg/yace/yace.go
@@ -1,5 +1,7 @@
 package yace
 
+// Package yace provides a client for the Yet Another Cloudwatch Exporter (YACE) packages
+
 import (
 	"context"
 	"log/slog"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for publishing and adds package-level documentation comments across multiple files to improve code readability and maintainability.

### CI/CD Workflow Addition:
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R1-R13): Added a new GitHub Actions workflow named `publish` that triggers on release events and includes a job to publish the Go package using the Go proxy.

### Documentation Improvements:
* [`pkg/controller/controller.go`](diffhunk://#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R3-R4): Added a package-level comment describing the purpose of the `controller` package.
* [`pkg/loaders/loaders.go`](diffhunk://#diff-e7e76a527c9cc638045791f5646bad3e149a9ae879e8ec0074ebdfb6e1157addR3-R4): Added a package-level comment for the `loaders` package and documentation for the `GetS3Loader` and `GetLocalFileLoader` functions. [[1]](diffhunk://#diff-e7e76a527c9cc638045791f5646bad3e149a9ae879e8ec0074ebdfb6e1157addR3-R4) [[2]](diffhunk://#diff-e7e76a527c9cc638045791f5646bad3e149a9ae879e8ec0074ebdfb6e1157addR15) [[3]](diffhunk://#diff-e7e76a527c9cc638045791f5646bad3e149a9ae879e8ec0074ebdfb6e1157addR47)
* [`pkg/logger/log.go`](diffhunk://#diff-15f9d860659d08a2842125d6e8904908dc9370f6f44350ba2e736833a1540fbfR3-R4): Added a package-level comment for the `logger` package.
* [`pkg/prom/prometheus.go`](diffhunk://#diff-20a3ce0c593754e1919fb7c95dd3a9aea1fcf835332b13a38985d55d04ec8d2cR3-R4): Added a package-level comment for the `prom` package.
* [`pkg/types/types.go`](diffhunk://#diff-8e49337a1417a39a62ebf427e84fb2faa566c96e37ae627ac484c05dbe65c483R3-R4): Added a package-level comment for the `types` package.
* [`pkg/yace/yace.go`](diffhunk://#diff-55b65ab88c28b9479cb7936da940036386dc618db60516b8b3f5bf0d79c14848R3-R4): Added a package-level comment for the `yace` package.