### PR TITLE
docs: refine comments and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,6 @@ Concurrency settings normally passed to YACE via command line flags can be manag
 Each flag controlling concurrency has a corresponding environment variable, in screaming snake case with the prefix "YACE".  
 Example: the flag "cloudwatch-concurrency" can be controlled through ```YACE_CLOUDWATCH_CONCURRENCY```.
 
+## Customization
+Go packages are available (https://pkg.go.dev/github.com/kjansson/yac-p) and can be used for custom applications.
+The code included in ```cmd``` is for the Lambda implementation and config file storage in S3, but can easily be adapted using custom config file loaders.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,6 +1,5 @@
+// Package controller provides the yac-p controller struct and its methods to manage the components of the application
 package controller
-
-// Package controller provides the Controller struct and its methods to manage the components of the application
 
 import (
 	"github.com/kjansson/yac-p/pkg/types"

--- a/pkg/loaders/loaders.go
+++ b/pkg/loaders/loaders.go
@@ -1,9 +1,8 @@
-package loaders
-
 // Package loaders provides functions to load configuration files from different sources.
 // Loaders are used when initializing the YACE client and allows for flexibility in how the configuration is loaded.
 // Custom loaders can be used if doing a custom implementation. A loader should return the YACE config file in a byte array along with any errors.
 // Example: func MyCustomLoader() func() ([]byte, error)...
+package loaders
 
 import (
 	"fmt"

--- a/pkg/logger/log.go
+++ b/pkg/logger/log.go
@@ -1,6 +1,6 @@
-package logger
-
 // Package logger provides a simple logging interface for yac-p
+// It implements the types.Logger interface
+package logger
 
 import (
 	"log/slog"

--- a/pkg/prom/prometheus.go
+++ b/pkg/prom/prometheus.go
@@ -1,6 +1,6 @@
+// Package prom provides a client for processing and persisting metrics to a Prometheus remote write endpoint.
+// It implements the types.MetricPersister interface.
 package prom
-
-// Package prom provides a client for processing and sending metrics to a Prometheus remote write endpoint.
 
 import (
 	"bytes"

--- a/pkg/tests/loaders.go
+++ b/pkg/tests/loaders.go
@@ -1,6 +1,5 @@
-package tests
-
 // Package tests provides test types and functions for yac-p
+package tests
 
 // GetTestConfigLoader returns a function that loads a static test configuration
 func GetTestConfigLoader() func() ([]byte, error) {

--- a/pkg/tests/types.go
+++ b/pkg/tests/types.go
@@ -1,6 +1,5 @@
-package tests
-
 // Package tests provides test types and functions for yac-p
+package tests
 
 import (
 	"context"

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,6 +1,5 @@
-package types
-
 // Package types defines interfaces and constants used in yac-p
+package types
 
 import (
 	yace "github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg"

--- a/pkg/yace/yace.go
+++ b/pkg/yace/yace.go
@@ -1,6 +1,6 @@
+// Package yace provides a client for the Yet Another Cloudwatch Exporter (YACE) packages for collecting metrics from AWS Cloudwatch.
+// It implements the types.MetricCollector interface.
 package yace
-
-// Package yace provides a client for the Yet Another Cloudwatch Exporter (YACE) packages
 
 import (
 	"context"

--- a/yace-config-example/config.yaml
+++ b/yace-config-example/config.yaml
@@ -7,8 +7,6 @@ discovery:
       - Environment
   jobs:
     - type: AWS/EC2
-      roles:
-        - arn:aws:iam::12345678912:role/org-observability
       regions: 
         - eu-north-1
       metrics:


### PR DESCRIPTION
This pull request introduces several changes to improve documentation, enhance code organization, and update configuration examples. The most significant updates include adding a customization section to the README, restructuring package comments for consistency, and modifying the example configuration file.

### Documentation Improvements:
* Added a "Customization" section to the `README.md`, detailing the availability of Go packages for custom applications and explaining how the code can be adapted for custom configuration file loaders.

### Code Organization Enhancements:
* Standardized package comments across multiple files (`pkg/controller/controller.go`, `pkg/loaders/loaders.go`, `pkg/logger/log.go`, `pkg/prom/prometheus.go`, `pkg/tests/loaders.go`, `pkg/tests/types.go`, `pkg/types/types.go`, `pkg/yace/yace.go`) to provide consistent descriptions of their purpose and implemented interfaces. [[1]](diffhunk://#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R1-L4) [[2]](diffhunk://#diff-e7e76a527c9cc638045791f5646bad3e149a9ae879e8ec0074ebdfb6e1157addL1-R5) [[3]](diffhunk://#diff-15f9d860659d08a2842125d6e8904908dc9370f6f44350ba2e736833a1540fbfL1-R3) [[4]](diffhunk://#diff-20a3ce0c593754e1919fb7c95dd3a9aea1fcf835332b13a38985d55d04ec8d2cR1-L4) [[5]](diffhunk://#diff-5c52be3ba53934bef7b04319220c3901f9a74e73cf1886f11ab863405d7ac30cL1-R2) [[6]](diffhunk://#diff-fdc1bbd3c3f600aa0075b30331040a86854d5f4e814e4b553e962cbe0e535e31L1-R2) [[7]](diffhunk://#diff-8e49337a1417a39a62ebf427e84fb2faa566c96e37ae627ac484c05dbe65c483L1-R2) [[8]](diffhunk://#diff-55b65ab88c28b9479cb7936da940036386dc618db60516b8b3f5bf0d79c14848R1-L4)

### Configuration Example Update:
* Removed the `roles` field from the `AWS/EC2` job configuration in the example `yace-config-example/config.yaml` file to simplify the example and focus on essential fields.