### PR TITLE
fix: move to v2

### DIFF
--- a/cmd/lambda/main.go
+++ b/cmd/lambda/main.go
@@ -6,9 +6,9 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 
 	"github.com/kjansson/defcon"
-	"github.com/kjansson/yac-p/pkg/controller"
-	"github.com/kjansson/yac-p/pkg/prom"
-	"github.com/kjansson/yac-p/pkg/types"
+	"github.com/kjansson/yac-p/v2/pkg/controller"
+	"github.com/kjansson/yac-p/v2/pkg/prom"
+	"github.com/kjansson/yac-p/v2/pkg/types"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.8
 
 require (
 	github.com/aws/aws-lambda-go v1.48.0
-	github.com/aws/aws-sdk-go v1.55.6
+	github.com/aws/aws-sdk-go v1.55.7
 	github.com/golang/snappy v1.0.0
 	github.com/kjansson/defcon v1.2.1
 	github.com/prometheus-community/yet-another-cloudwatch-exporter v0.62.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/aws/aws-lambda-go v1.48.0 h1:1aZUYsrJu0yo5fC4z+Rba1KhNImXcJcvHu763BxoyIo=
 github.com/aws/aws-lambda-go v1.48.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
-github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
-github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
+github.com/aws/aws-sdk-go v1.55.7 h1:UJrkFq7es5CShfBwlWAC8DA077vp8PyVbQd3lqLiztE=
+github.com/aws/aws-sdk-go v1.55.7/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.32.7 h1:ky5o35oENWi0JYWUZkB7WYvVPP+bcRF5/Iq7JWSb5Rw=
 github.com/aws/aws-sdk-go-v2 v1.32.7/go.mod h1:P5WJBrYqqbWVaOxgH0X/FYYD47/nooaPOZPlQdmiN2U=
 github.com/aws/aws-sdk-go-v2/config v1.28.7 h1:GduUnoTXlhkgnxTD93g1nv4tVPILbdNQOzav+Wpg7AE=

--- a/internal/test_utils/types.go
+++ b/internal/test_utils/types.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/kjansson/yac-p/pkg/types"
+	"github.com/kjansson/yac-p/v2/pkg/types"
 	yace "github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg"
 	client "github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/clients/v2"
 	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/model"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -2,10 +2,10 @@
 package controller
 
 import (
-	"github.com/kjansson/yac-p/pkg/logger"
-	"github.com/kjansson/yac-p/pkg/prom"
-	"github.com/kjansson/yac-p/pkg/types"
-	"github.com/kjansson/yac-p/pkg/yace"
+	"github.com/kjansson/yac-p/v2/pkg/logger"
+	"github.com/kjansson/yac-p/v2/pkg/prom"
+	"github.com/kjansson/yac-p/v2/pkg/types"
+	"github.com/kjansson/yac-p/v2/pkg/yace"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/prompb"
 )

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -3,8 +3,8 @@ package controller
 import (
 	"testing"
 
-	"github.com/kjansson/yac-p/internal/test_utils"
-	"github.com/kjansson/yac-p/pkg/types"
+	"github.com/kjansson/yac-p/v2/internal/test_utils"
+	"github.com/kjansson/yac-p/v2/pkg/types"
 )
 
 func TestConfigLoad(t *testing.T) {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/kjansson/yac-p/pkg/types"
+	"github.com/kjansson/yac-p/v2/pkg/types"
 )
 
 type SlogLogger struct {

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kjansson/yac-p/pkg/types"
+	"github.com/kjansson/yac-p/v2/pkg/types"
 )
 
 // {"time":"2025-04-23T16:53:55.002724+02:00","level":"INFO","msg":"test message","key1":"value1"}

--- a/pkg/prom/prometheus.go
+++ b/pkg/prom/prometheus.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/golang/snappy"
-	"github.com/kjansson/yac-p/pkg/types"
+	"github.com/kjansson/yac-p/v2/pkg/types"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/prompb"
 )

--- a/pkg/prom/prometheus_test.go
+++ b/pkg/prom/prometheus_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/kjansson/yac-p/pkg/logger"
-	"github.com/kjansson/yac-p/pkg/types"
+	"github.com/kjansson/yac-p/v2/pkg/logger"
+	"github.com/kjansson/yac-p/v2/pkg/types"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/prompb"
 	"google.golang.org/protobuf/proto"

--- a/pkg/yace/yace.go
+++ b/pkg/yace/yace.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/kjansson/yac-p/pkg/types"
+	"github.com/kjansson/yac-p/v2/pkg/types"
 	yace "github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg"
 	client "github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/clients/v2"
 	yace_config "github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/config"

--- a/pkg/yace/yace_test.go
+++ b/pkg/yace/yace_test.go
@@ -3,8 +3,8 @@ package yace
 import (
 	"testing"
 
-	"github.com/kjansson/yac-p/internal/test_utils"
-	"github.com/kjansson/yac-p/pkg/types"
+	"github.com/kjansson/yac-p/v2/internal/test_utils"
+	"github.com/kjansson/yac-p/v2/pkg/types"
 )
 
 func TestConfigLoad(t *testing.T) {


### PR DESCRIPTION
BREAKING CHANGE: Moves all env var configuration out of packages, config now part of types

* Moves testing utils to internal packages
* Adds a New function to controller for easier initializing
* Improved testing for packages and testing now only uses package components
* Config file loaders moved out of packages and now part of cmd for easier customisation
* More configuration options for logger to enable better tests