### PR TITLE
feat: error checks

### DIFF
--- a/cmd/lambda/controller.go
+++ b/cmd/lambda/controller.go
@@ -1,4 +1,3 @@
-// Package controller provides the yac-p controller struct and its methods to manage the components of the application
 package main
 
 import (
@@ -36,7 +35,7 @@ func NewController(config Config) (*types.Controller, error) {
 
 	converter := converter.NewConverter(logger)
 
-	persister := prom.NewPromClient(
+	persister, err := prom.NewPromClient(
 		config.RemoteWriteURL,
 		config.AuthType,
 		config.AuthToken,
@@ -46,6 +45,9 @@ func NewController(config Config) (*types.Controller, error) {
 		config.PrometheusRegion,
 		config.AWSRoleARN,
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	c := &types.Controller{
 		Logger:    logger,

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -2,6 +2,7 @@
 package logger
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 )
@@ -29,6 +30,12 @@ func NewLogger(LogDestination *os.File, LogFormat string, Debug bool) (*SlogLogg
 		destination = LogDestination
 	} else {
 		destination = os.Stdout
+	}
+
+	if LogFormat != "" {
+		if LogFormat != "json" && LogFormat != "JSON" && LogFormat != "text" && LogFormat != "TEXT" {
+			return nil, fmt.Errorf("invalid log format: %s", LogFormat)
+		}
 	}
 
 	if LogFormat == "json" || LogFormat == "JSON" {

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -95,3 +95,11 @@ func TestLogFormat(t *testing.T) {
 		t.Fatalf("Expected JSON format, got '%s'", string(entry[:n]))
 	}
 }
+
+func TestLogFormatInit(t *testing.T) {
+
+	_, err := NewLogger(os.Stdout, "wrongformat", false)
+	if err == nil {
+		t.Fatalf("Expected error for invalid log format, got nil")
+	}
+}

--- a/pkg/persister/prom/prometheus.go
+++ b/pkg/persister/prom/prometheus.go
@@ -39,7 +39,23 @@ func NewPromClient(
 	region string,
 	prometheusRegion string,
 	awsRoleARN string,
-) *PromClient {
+) (*PromClient, error) {
+
+	if remoteWriteURL == "" {
+		return nil, fmt.Errorf("prometheus remote write URL must be set")
+	}
+
+	if authType == "BASIC" { // Basic auth requires username and password
+		if username == "" || password == "" {
+			return nil, fmt.Errorf("username and password must be set for BASIC auth")
+		}
+	}
+	if authType == "TOKEN" { // Token auth requires token
+		if authToken == "" {
+			return nil, fmt.Errorf("auth token must be set for TOKEN auth")
+		}
+	}
+
 	return &PromClient{
 		RemoteWriteURL:   remoteWriteURL,
 		AuthType:         authType,
@@ -49,7 +65,7 @@ func NewPromClient(
 		Region:           region,
 		PrometheusRegion: prometheusRegion,
 		AWSRoleARN:       awsRoleARN,
-	}
+	}, nil
 }
 
 // PeristMetrics creates a Prometheus remote write request and sends it to the remote write URL

--- a/pkg/persister/prom/prometheus_test.go
+++ b/pkg/persister/prom/prometheus_test.go
@@ -38,6 +38,52 @@ func createTestTimeSeries() []prompb.TimeSeries {
 	}
 }
 
+func TestAuthOptions(t *testing.T) {
+
+	_, err := NewPromClient(
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+	)
+	if err == nil {
+		t.Fatalf("Expected error for empty Prometheus URL, got nil")
+	}
+
+	_, err = NewPromClient(
+		"http://localhost:9090/api/v1/write",
+		"BASIC",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+	)
+	if err == nil {
+		t.Fatalf("Expected error for empty basic auth credentials, got nil")
+	}
+
+	_, err = NewPromClient(
+		"http://localhost:9090/api/v1/write",
+		"TOKEN",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+	)
+	if err == nil {
+		t.Fatalf("Expected error for empty token auth credentials, got nil")
+	}
+
+}
+
 func TestMetricsPersistingNoAuth(t *testing.T) {
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This pull request introduces error handling improvements and validation logic in the `NewPromClient` and `NewLogger` functions, along with corresponding test cases to ensure robustness. Additionally, minor cleanup and formatting changes are included.

### Error handling and validation improvements:

* [`pkg/persister/prom/prometheus.go`](diffhunk://#diff-3b556ded79ff8e0fa0e2afd93c6a850b5bbd110f544e518a60e2ac6276c49286L42-R58): Updated `NewPromClient` to return an error if the `remoteWriteURL` is empty or if required authentication credentials (username/password for BASIC auth or token for TOKEN auth) are missing. [[1]](diffhunk://#diff-3b556ded79ff8e0fa0e2afd93c6a850b5bbd110f544e518a60e2ac6276c49286L42-R58) [[2]](diffhunk://#diff-3b556ded79ff8e0fa0e2afd93c6a850b5bbd110f544e518a60e2ac6276c49286L52-R68)
* [`pkg/logger/logger.go`](diffhunk://#diff-c1dc2eb1e149a1dc7ecd5cb474e167fb456eb7ad0ea0256cf62fba693a89af79R35-R40): Added validation in `NewLogger` to ensure the provided log format is either "json" or "text", returning an error for invalid formats.

### Test cases for validation:

* [`pkg/logger/logger_test.go`](diffhunk://#diff-1b8d9e7644b6bb4b1cbd02d902261663a31e2f4792231472ee673265132a6913R98-R105): Added `TestLogFormatInit` to verify that `NewLogger` returns an error for invalid log formats.
* [`pkg/persister/prom/prometheus_test.go`](diffhunk://#diff-8e9f4927fe942099be6827167231e2e413eb57f4f2ead2d3306c4d6a95760356R41-R86): Added `TestAuthOptions` to validate error handling in `NewPromClient` for empty `remoteWriteURL` and missing authentication credentials.

### Code cleanup:

* [`cmd/lambda/controller.go`](diffhunk://#diff-97525b88ac44388cfbf7e3e28e4f3cf4163cd74fef415ae41c7e72b59c204cafL39-R38): Fixed error handling in `NewController` by checking and returning errors from `NewPromClient`. [[1]](diffhunk://#diff-97525b88ac44388cfbf7e3e28e4f3cf4163cd74fef415ae41c7e72b59c204cafL39-R38) [[2]](diffhunk://#diff-97525b88ac44388cfbf7e3e28e4f3cf4163cd74fef415ae41c7e72b59c204cafR48-R50)
* [`pkg/logger/logger.go`](diffhunk://#diff-c1dc2eb1e149a1dc7ecd5cb474e167fb456eb7ad0ea0256cf62fba693a89af79R5): Added a missing `fmt` import for error formatting.