### PR TITLE
fix: update release-please config to trigger patch release on deps up…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
This pull request includes a small update to the `.github/dependabot.yml` file. The change adds a `commit-message` configuration with a `prefix` set to `"deps"`.